### PR TITLE
Update Poetry dependency section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 .idea
+.vscode/
 .venv
 poetry.lock
 __pycache__/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ python = ">=3.8, <4.0"
 substrate-interface = ">=1.4.0, <2.0"
 click = "^8.0.4"
 
-[tool.poetry.dev-dependencies]
+[tool.poetry.group.dev.dependencies]
 Sphinx = "^4.4.0"
 black = "^22.1.0"
 


### PR DESCRIPTION
Updates the deprecated `poetry.dev-dependencies` section to the current Poetry dependency group format.